### PR TITLE
Keypad numbers to regular numbers

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -170,6 +170,11 @@ window.Mousetrap = (function() {
             return 91;
         }
 
+        // map keypad numbers to top-of-keyboard numbers
+        if (e.keyCode >= 96 && e.keyCode <= 105){
+            return e.keyCode - 48;
+        }
+
         return e.keyCode;
     }
 


### PR DESCRIPTION
In your demo, the "4" keyboard shortcut does not fire when "4" is pressed on a keyboard's numeric keypad. I am not sure if that was intentional, or simply overlooked. 
