### PR TITLE
Batch key binding, as per davoclavo's suggestion

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -584,6 +584,25 @@ window.Mousetrap = (function() {
         },
 
         /**
+        * batch version of bind()
+        *
+        * accepts an object in the format {key: callback} and binds each
+        * key to its callback using bind
+        *
+        * it's not possible to change the action from the default
+        *
+        * @param {object} keys_callbacks
+        * @returns void
+        */
+        bindMany: function(keys_callbacks) {
+            for (var key in keys_callbacks) {
+                if (keys_callbacks.hasOwnProperty(key)) {
+                    this.bind(key, keys_callbacks[key]);
+                }
+            }
+        },
+
+        /**
          * triggers an event that has already been bound
          *
          * @param {string} keys


### PR DESCRIPTION
Hi. This is a simple patch that just adds a method so you can do 

``` javascript
Mousetrap.bindMany({
    '3': function() { alert(3); },
    't': function() { alert('t'); }
}); 
```

Not sure if you see this as an improvement or unnecessary bloat, though ;)
