### PR TITLE
Add AMD Module Support

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -626,8 +626,6 @@
     // If the script is being loaded as an AMD module...
     if(typeof define != 'undefined') {
         
-        console.log('hello');
-        
         // Then define it as one, without making it global
         define(_Mousetrap);
     


### PR DESCRIPTION
The Mousetrap object is only added to the global scope if a "define" function isn't present. Otherwise, it will call this function to define Mousetrap as an AMD module. Everything else remains unchanged. 
