### PR TITLE
Added unbind method

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -700,7 +700,6 @@ window.Mousetrap = (function() {
          *
          * the unbinding just sets the callback function of that keycombo as an empty function
          * and deletes the corresponding key in the _direct_map dict.
-
          * the keycombo+action has to be exactly the same as it was defined in the bind method
          *
          * @param {string|Array} keys


### PR DESCRIPTION
Simple yet not so fancy solution, without the need to go through all the bind methods to 'parse' the keys.
instead it replaces the callback with an empty function and removes its entry from _direct_map dict
