### PR TITLE
Binding options and stopping callbacks on a per-bind basis

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -733,14 +733,20 @@
          *
          * @param {string|Array} keys
          * @param {Function} callback
-         * @param {string=} action - 'keypress', 'keydown', or 'keyup'
+         * @param {object} options - includes optional arguments: 
+         *      action ('keypress', 'keydown', or 'keyup') - type of event to listen for,
+         *      includeEditable (boolean) - if set to true, the callback will fire even if the cursor is focused on an editable element (input, select, textarea)
          * @param {boolean|undefined} indicates whether to fire the callback on editable elements or not
          * @returns void
          */
-        bind: function(keys, callback, action, suppressOnEditable) {
+        bind: function(keys, callback, options) {
+            // if it's a string, treat options as action for backward compatibility
+            var action = typeof options === 'string' ? options : options && options.action;
             _bindMultiple(keys instanceof Array ? keys : [keys], callback, action);
             _direct_map[keys + ':' + action] = callback;
-            suppressOnEditable && _suppressedCallbacks.push(callback);
+            if (!options || !options.includeEditable) {
+                _suppressedCallbacks.push(callback);
+            }
             return this;
         },
 


### PR DESCRIPTION
This change encourages to use the `bind`'s optional argument as a dictionary, but it also maintains backward compatibility, if someone wants to use it as an `action` string or doesn't use it at all. You can also specify if you want  to execute callbacks even if the focus is on an editable element like `<input>`, `<select>` and `<textarea>`.

Examples:

<pre>
Mousetrap.bind('command+f', function(ev) { ... }, { action: 'keypress', includeEditable: true });
// backward compatible:
Mousetrap.bind('command+f', function(ev) { ... }, 'keydown'); 
Mousetrap.bind('command+f', function(ev) { ... }); 
</pre>


`includeEditable` if false by default.
