### PR TITLE
Fixed the breaking of sequences by binding their starting character to a key. Issue #86

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -329,9 +329,8 @@
 
                 // remove is used so if you change your mind and call bind a
                 // second time with a new function the first one is overwritten
-                // But don't stomp over a key if its in a sequence (&& !callback.seq). This 
-                // fixes an issue where a binding of a single key which is the first in a 
-                // sequence after the sequence has been defined.
+                // But don't remove a key if its in a sequence (&& !callback.seq). Side 
+                // effect: can't re-bind sequences.
                 if (remove && callback.combo == combination && !callback.seq) {
                     _callbacks[character].splice(i, 1);
                 }


### PR DESCRIPTION
To test the fix try the difference between:

```
Mousetrap.bind("a", function() {console.log("a");});
Mousetrap.bind("a b c", function() {console.log("abc");});
```

and

```
Mousetrap.bind("a b c", function() {console.log("abc");});
Mousetrap.bind("a", function() {console.log("a");});
```

The latter example now works with this fix. Before it binding the "a" after the sequence would remove the "a" from the sequence thus making it impossible to then do the sequence.

The whole issues is moot for now however because if there is a sequence the first character cannot fire by itself because we don't know if its a sequence or not so the code currently assumes it is and doesn't fire the individual key.

But... there is a feature request out for that too which I'm tinkering with, so this is a precursor.

Side effect of the fix is that you can't re-bind the same sequence.
