### PR TITLE
.unbind() now accepts an array

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -772,8 +772,8 @@
          * @param {string} action
          * @returns void
          */
-        unbind: function(keys, action) {
-	    _unbindMultiple(keys instanceof Array ? keys : [keys], action);
+        unbind: function(keys, action){
+            _unbindMultiple(keys instanceof Array ? keys : [keys], action);
             return this;
         },
 


### PR DESCRIPTION
It's now possible to do this: 
`Mousetrap.unbind(['esc','enter']);`
