### PR TITLE
Fix error with trigger()

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -772,7 +772,9 @@
          * @returns void
          */
         trigger: function(keys, action) {
-            _direct_map[keys + ':' + action]();
+            if (_direct_map[keys + ':' + action]) {
+                _direct_map[keys + ':' + action]();
+            }
             return this;
         },
 


### PR DESCRIPTION
Was breaking if you tried to trigger a key that didn't have a function bound to it. Didn't update the minified file.
