### PR TITLE
Add generic `mod` alias for command/ctrl

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -124,7 +124,8 @@
             'option': 'alt',
             'command': 'meta',
             'return': 'enter',
-            'escape': 'esc'
+            'escape': 'esc',
+            'mod': /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? 'meta' : 'ctrl'
         },
 
         /**


### PR DESCRIPTION
Add a generic `mod` modifier, which is an alias for `command` on OS X, and `ctrl` everywhere else.

`mod` might not be the best name for it, so I'm open to suggestions.
