### PR TITLE
add bower and component support

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "json": "bower.json"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "mousetrap",
+  "description": "Simple library for handling keyboard shortcuts in Javascript",
+  "version": "1.3.0",
+  "main": [
+    "mousetrap.js"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+  "name": "mousetrap",
+  "description": "Simple library for handling keyboard shortcuts in Javascript",
+  "version": "1.3.0",
+  "main": "mousetrap.js",
+  "scripts": [
+    "mousetrap.js"
+  ]
+}

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -810,11 +810,15 @@
         }
     };
 
-    // expose mousetrap to the global object
-    window.Mousetrap = Mousetrap;
+    if (typeof module === 'object' && typeof module.exports === 'object') {
+        module.exports = Mousetrap;
+    } else {
+        // expose mousetrap to the global object
+        window.Mousetrap = Mousetrap;
 
-    // expose mousetrap as an AMD module
-    if (typeof define === 'function' && define.amd) {
-        define(Mousetrap);
+        // expose mousetrap as an AMD module
+        if (typeof define === 'function' && define.amd) {
+            define(Mousetrap);
+        }
     }
 }) ();


### PR DESCRIPTION
Add a bower.json and component.json for bower and component support, respectively. They have similar yet incompatible specifications. 

I also added commonjs support to your code, basically copying what jQuery does: https://github.com/jquery/jquery/blob/master/src/exports.js.

Only downside is that now you have to update your versions in both files.
