### PR TITLE
Prevent keypress events firing from inside Flash

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -826,7 +826,7 @@
             }
 
             // stop for input, select, and textarea
-            return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || (element.contentEditable && element.contentEditable == 'true');
+            return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || element.tagName == 'OBJECT' || element.tagName == 'EMBED' || (element.contentEditable && element.contentEditable == 'true');
         },
 
         /**


### PR DESCRIPTION
Hello,

In the latest Chrome (26.0.1410.65, although it may have been happening sooner) Mousetrap is catching keypresses when Flash is focused. I figure these should be on the default blacklist as Flash movies may be implementing their own behaviours and can have textarea type elements, etc.

Cheers,
James
