### PR TITLE
Recognize contenteditable plaintext-only

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -892,7 +892,7 @@
             }
 
             // stop for input, select, and textarea
-            return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || (element.contentEditable && element.contentEditable == 'true');
+            return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || (element.contentEditable && (element.contentEditable == 'true' || element.contentEditable == 'plaintext-only'));
         },
 
         /**


### PR DESCRIPTION
It should now return on elements with contenteditable="plaintext-only" (webkit only).
