### PR TITLE
add methods to expose _MAP, _KEYCODE_MAP, and _SHIFT_MAP

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -924,6 +924,10 @@
           return _MAP;
         },
         
+        getReverseMap: function() {
+            return _getReverseMap();
+        },
+        
         getKeycodeMap: function() {
           return _KEYCODE_MAP;
         },

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -918,7 +918,19 @@
         /**
          * exposes _handleKey publicly so it can be overwritten by extensions
          */
-        handleKey: _handleKey
+        handleKey: _handleKey,
+        
+        getMap: function() {
+          return _MAP;
+        },
+        
+        getKeycodeMap: function() {
+          return _KEYCODE_MAP;
+        },
+        
+        getShiftMap: function() {
+          return _SHIFT_MAP;
+        }
     };
 
     // expose mousetrap to the global object

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -565,3 +565,22 @@ describe('Mousetrap.unbind', function() {
         expect(spy.callCount).to.equal(3, 'callback should not fire after unbind');
     });
 });
+
+describe('Mousetrap.getMap', function() {
+    it('returns mapping', function() {
+      expect(Mousetrap.getMap()).not.to.equal(undefined);
+    });
+});
+
+describe('Mousetrap.getKeycodeMap', function() {
+    it('returns mapping', function() {
+      expect(Mousetrap.getKeycodeMap()).not.to.equal(undefined);
+    });
+});
+
+
+describe('Mousetrap.getShiftMap', function() {
+    it('returns mapping', function() {
+      expect(Mousetrap.getShiftMap()).not.to.equal(undefined);
+    });
+});

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -572,6 +572,12 @@ describe('Mousetrap.getMap', function() {
     });
 });
 
+describe('Mousetrap.getReverseMap', function() {
+    it('returns mapping', function() {
+      expect(Mousetrap.getReverseMap()).not.to.equal(undefined);
+    });
+});
+
 describe('Mousetrap.getKeycodeMap', function() {
     it('returns mapping', function() {
       expect(Mousetrap.getKeycodeMap()).not.to.equal(undefined);


### PR DESCRIPTION
Add methods to expose _MAP, _KEYCODE_MAP, and _SHIFT_MAP from Mousetrap, nothing particularly earth shattering. I am using these to show users what bindings they have available and in turn generate dynamic bindings.
