### PR TITLE
Adding BUTTON check to stopCallback method

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -982,6 +982,12 @@
             return false;
         }
 
+        // If the focused element is a button and the 'enter' key is pressed,
+        // we shouldn't process that key
+        if (element.tagName == 'BUTTON' && e.keyCode === 13) {
+            return true;
+        }
+
         // stop for input, select, and textarea
         return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || element.isContentEditable;
     };


### PR DESCRIPTION
I ran into the problem where I had `enter` mapped to open an item in a list, and on the same page had a `button` that you could click. If I tabbed to the button and pressed `enter`, the currently selected item would be opened instead of the button action being executed. I feel like this is a pretty common case, especially if you are implementing keyboard shortcuts on your site. Also, I couldn't think of a valid example where you **would** want mousetrap to handle `enter` on a button.
