### PR TITLE
Modules define was incorrect. Now defines modules name, no dependencies,...

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -926,6 +926,8 @@
 
     // expose mousetrap as an AMD module
     if (typeof define === 'function' && define.amd) {
-        define(Mousetrap);
+        define('mousetrap', [], function() {
+            return Mousetrap;
+        });
     }
 }) (window, document);


### PR DESCRIPTION
... and exports the Mousetrap namespace