### PR TITLE
Added Mousetrap.getCallback to get a callback

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -897,6 +897,18 @@
             return this;
         },
 
+        /**
+         * returns defined callback for specific keys 
+         *
+         * @param {String/Array} keys
+         * @param {String} action
+         * @returns {Function} callback for keys
+         */
+        getCallback: function(keys, action)
+        {
+            return _directMap[keys + ':' + action];
+        },
+
        /**
         * should we stop this event before firing off callbacks
         *


### PR DESCRIPTION
Added method to get the currently defined callback for a specified key combination. Useful when you need to temporarily use a key for something else.
