### PR TITLE
Refer to Mousetrap through window in plugins for better compiler support

### DIFF
--- a/plugins/bind-dictionary/mousetrap-bind-dictionary.js
+++ b/plugins/bind-dictionary/mousetrap-bind-dictionary.js
@@ -14,7 +14,7 @@
  *
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
+window.Mousetrap = (function(Mousetrap) {
     var self = Mousetrap,
         _oldBind = self.bind,
         args;
@@ -36,4 +36,4 @@ Mousetrap = (function(Mousetrap) {
     };
 
     return self;
-}) (Mousetrap);
+}) (window.Mousetrap);

--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -7,7 +7,7 @@
  * Mousetrap.bindGlobal('ctrl+s', _saveChanges);
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
+window.Mousetrap = (function(Mousetrap) {
     var _globalCallbacks = {},
         _originalStopCallback = Mousetrap.stopCallback;
 
@@ -33,4 +33,4 @@ Mousetrap = (function(Mousetrap) {
     };
 
     return Mousetrap;
-}) (Mousetrap);
+}) (window.Mousetrap);

--- a/plugins/pause/mousetrap-pause.js
+++ b/plugins/pause/mousetrap-pause.js
@@ -4,7 +4,7 @@
  * without having to reset Mousetrap and rebind everything
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
+window.Mousetrap = (function(Mousetrap) {
     var self = Mousetrap,
         _originalStopCallback = self.stopCallback,
         enabled = true;
@@ -26,4 +26,4 @@ Mousetrap = (function(Mousetrap) {
     };
 
     return self;
-}) (Mousetrap);
+}) (window.Mousetrap);

--- a/plugins/record/mousetrap-record.js
+++ b/plugins/record/mousetrap-record.js
@@ -186,4 +186,4 @@
         _recordedSequenceCallback = callback;
     };
 
-})(Mousetrap);
+})(window.Mousetrap);


### PR DESCRIPTION
If Mousetrap and a plugin are compiled together using Closure compiler with the
ADVANCED_OPTIMIZATIONS flag, the compiler needs to be certain that the Mousetrap
object referred to by the plugin is the one created in the main Mousetrap
definition. However, plugin definitions used to refer to Mousetrap without going
through window, so the compiler thought it was a different object. Fix this by
referring to window.Mousetrap also in plugins.
