### PR TITLE
Added bind handle

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -22,3 +22,7 @@ Allows you to temporarily prevent Mousetrap events from firing.
 ## Record
 
 Allows you to capture a keyboard shortcut or sequence defined by a user.
+
+## Bind handle
+
+Allows you to unbind and rebind a specific binding through a returned handle.

--- a/plugins/bind-handle/README.md
+++ b/plugins/bind-handle/README.md
@@ -1,0 +1,15 @@
+# Bind handle
+
+This extension alters Mousetrap bindings to return a handle, allowing manipulation of the specific binding. This is useful if you want to remove a specific binding at a later stage.
+
+Usage looks like:
+
+```javascript
+var handle = Mousetrap.bind('4', function() { highlight(2); });
+
+// stop the binding from firing
+handle.unbind();
+
+// allow binding to fire again
+handle.bind();
+```

--- a/plugins/bind-handle/mousetrap-bind-handle.js
+++ b/plugins/bind-handle/mousetrap-bind-handle.js
@@ -1,0 +1,34 @@
+/**
+ * This extension alters Mousetrap bindings to return a handle,
+ * allowing manipulation of the specific binding. This is 
+ * useful if you want to remove a specific binding at a later
+ * stage.
+ */
+/* global Mousetrap:true */
+Mousetrap = (function(Mousetrap) {
+    var self = Mousetrap,
+        _originalBind = Mousetrap.bind;
+        
+    self.bind = function(keys, originalCallback, action) {
+        var isBound = true;
+        
+        var callback = function() {
+            if (!isBound) {
+                return;
+            }
+            originalCallback.apply(this, arguments);
+        };
+        
+        _originalBind(keys, callback, action);
+        
+        return {
+            unbind: function() {
+                isBound = false;
+            },
+            bind: function() {
+                isBound = true;
+            }
+        };
+    };
+    return Mousetrap;
+})(Mousetrap);

--- a/plugins/bind-handle/mousetrap-bind-handle.min.js
+++ b/plugins/bind-handle/mousetrap-bind-handle.min.js
@@ -1,0 +1,1 @@
+Mousetrap=function(e){var t=e,n=e.bind;t.bind=function(e,t,r){var i=true;var s=function(){if(!i){return}t.apply(this,arguments)};n(e,s,r);return{unbind:function(){i=false},bind:function(){i=true}}};return e}(Mousetrap)

--- a/plugins/bind-handle/tests/banana.css
+++ b/plugins/bind-handle/tests/banana.css
@@ -1,0 +1,4 @@
+body {
+    font-family: helvetica, arial, sans-serif;
+    line-height: 20px;
+}

--- a/plugins/bind-handle/tests/banana.js
+++ b/plugins/bind-handle/tests/banana.js
@@ -1,0 +1,39 @@
+/**
+ * Peanut butter goes great with banana.
+ *
+ * @author Thomas Coats <thomas.coats@gmail.com>
+ */
+var Banana = (function() {
+    var toggleBindButton = $("button.test-toggle-bind"),
+        testResult = $(".test-bind-handle-result");
+    
+    var handle = null;
+    var isBound = false;
+    
+    function _prepareToggleBindTest() {
+        handle = Mousetrap.bind("b", function() {
+            testResult.text(testResult.text() + "x");
+        });
+        isBound = true;
+    }
+    
+    function _toggleBindTest() {
+        if (isBound) {
+            handle.unbind();
+            isBound = false;
+            toggleBindButton.text("Bind");
+        }
+        else {
+            handle.bind();
+            isBound = true;
+            toggleBindButton.text("Unbind");
+        }
+    }
+    
+    return {
+        mash: function () {
+            _prepareToggleBindTest();
+            toggleBindButton.click(_toggleBindTest);
+        }
+    }
+})();

--- a/plugins/bind-handle/tests/index.html
+++ b/plugins/bind-handle/tests/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <title>Banana</title>
+        <meta charset=utf-8>
+        <link href="banana.css" rel="stylesheet">
+    </head>
+
+    <body>
+        <h1>Banana</h1>
+
+        <h2>For testing the <strong>bind handle</strong> extension</h2>
+        
+        <p>Pressing "b" does something.</p>
+
+        <p>Click "Unbind" to stop it working and "Bind" to make it work again.</p>
+        <button class="test-toggle-bind">Unbind</button>
+        
+        <div class="test-bind-handle-result"></div>
+
+        <script type="text/javascript" src="../../../tests/libs/jquery-1.7.2.min.js"></script>
+        <script type="text/javascript" src="../../../mousetrap.js"></script>
+        <script type="text/javascript" src="../mousetrap-bind-handle.min.js"></script>
+        <script type="text/javascript" src="banana.js"></script>
+
+        <script type="text/javascript">
+            Banana.mash();
+        </script>
+    </body>
+
+</html>


### PR DESCRIPTION
This extension alters Mousetrap bindings to return a handle, allowing manipulation of the specific binding. This is useful if you want to remove a specific binding at a later stage.

What do you think?
