### PR TITLE
Add handleKeyEvent to Mousetrap object to let follow events

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -928,10 +928,6 @@
         * @return {boolean}
         */
         stopCallback: function(e, element) {
-            if (e.mousetrap == true) {
-                return false;
-            }
-            
             // if the element has the class "mousetrap" then no need to stop
             if ((' ' + element.className + ' ').indexOf(' mousetrap ') > -1) {
                 return false;


### PR DESCRIPTION
For example when using Mousetrap with Ace Editor, ace capture all the events in the editor and shortcuts from mousetrap are not triggered, using this change and this ace code:

```
var $input = editor.textInput.getElement();
var keyboardShortcutsFollow = function(e) {
    e.mousetrap = true;
    Mousetrap.handleKeyEvent(e);
};
$input.addEventListener('keypress', keyboardShortcutsFollow, false);
$input.addEventListener('keydown', keyboardShortcutsFollow, false);
$input.addEventListener('keyup', keyboardShortcutsFollow, false);
```

It works.
