### PR TITLE
fixed spelling of JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mousetrap
 
-Mousetrap is a simple library for handling keyboard shortcuts in Javascript.
+Mousetrap is a simple library for handling keyboard shortcuts in JavaScript.
 
 It is licensed under the Apache 2.0 license.
 

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Mousetrap is a simple keyboard shortcut library for Javascript with
+ * Mousetrap is a simple keyboard shortcut library for JavaScript with
  * no external dependencies
  *
  * @version 1.4.6


### PR DESCRIPTION
please excuse my pedantry, it's a bit of a pet peeve

note that the same spelling occurs in the repository description, which of course I cannot modify
