### PR TITLE
Tests for bindings that may conflict on certain keyboard layouts

### DIFF
--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -12,7 +12,7 @@ describe('Mousetrap.bind', function() {
 
             Mousetrap.bind('/', spy);
 
-            KeyEvent.simulate('/'.charCodeAt(0), 90);
+            KeyEvent.simulate('/'.charCodeAt(0), 191);
 
             // really slow for some reason
             // expect(spy).to.have.been.calledOnce;
@@ -25,7 +25,7 @@ describe('Mousetrap.bind', function() {
 
             Mousetrap.bind('?', spy);
 
-            KeyEvent.simulate('?'.charCodeAt(0), 90);
+            KeyEvent.simulate('?'.charCodeAt(0), 191);
 
             // really slow for some reason
             // expect(spy).to.have.been.calledOnce;
@@ -40,7 +40,7 @@ describe('Mousetrap.bind', function() {
             Mousetrap.bind('?', spy);
             Mousetrap.bind('/', spySlash);
 
-            KeyEvent.simulate('/'.charCodeAt(0), 90);
+            KeyEvent.simulate('/'.charCodeAt(0), 191);
 
             // really slow for some reason
             // expect(spy).to.have.been.calledOnce;
@@ -54,7 +54,7 @@ describe('Mousetrap.bind', function() {
             Mousetrap.bind('?', spy);
             Mousetrap.bind('/', spySlash);
 
-            KeyEvent.simulate('?'.charCodeAt(0), 90);
+            KeyEvent.simulate('?'.charCodeAt(0), 191);
 
             // really slow for some reason
             // expect(spy).to.have.been.calledOnce;


### PR DESCRIPTION
I noticed with similar libraries that they can't separate the key strokes for / and ? on some keyboard layouts.
On Swedish Qwerty / is shift-7 and ? is shift-+ and both reports as key code 191 in the event.which property.

The additional tests in this PR verifies that Mousetrap can separate these bindings.
