### PR TITLE
Expose characterFromEvent for games

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -940,7 +940,12 @@
         /**
          * exposes _handleKey publicly so it can be overwritten by extensions
          */
-        handleKey: _handleKey
+        handleKey: _handleKey,
+
+        /**
+         * exposes _characterFromEvent publicly so it can be used in non evented systems (like games).
+         */
+        characterFromEvent: _characterFromEvent
     };
 
     // expose mousetrap to the global object


### PR DESCRIPTION
I want to expose `_characterFromEvent` as it is a useful external function for when you cannot rely on events.

Games have a high data mutation rate, and nearly always run on game loops.  In future I'd love to see a way to get the key combinations working without event binding, but for now just being able to access single keys is a big win.

Cheers