### PR TITLE
Add spm support

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -943,11 +943,15 @@
         handleKey: _handleKey
     };
 
-    // expose mousetrap to the global object
-    window.Mousetrap = Mousetrap;
-
+    // commonjs
+    if (typeof module === 'object') {
+        module.exports = Mousetrap;
     // expose mousetrap as an AMD module
-    if (typeof define === 'function' && define.amd) {
+    } else if (typeof define === 'function' && define.amd) {
         define(Mousetrap);
+    // expose mousetrap to the global object
+    } else {
+        window.Mousetrap = Mousetrap;
     }
+
 }) (window, document);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mousetrap",
+  "name": "mousetrap",
   "version": "1.4.6",
   "description": "Simple library for handling keyboard shortcuts",
   "main": "mousetrap.js",
@@ -26,5 +26,11 @@
     "grunt": "~0.4.1",
     "grunt-complexity": "~0.1.2",
     "grunt-mocha": "~0.3.1"
+  },
+  "spm": {
+    "main": "mousetrap.js",
+    "ignore": [
+      "tests"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/mousetrap

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of mousetrap in spmjs, I can add it for your account after signing in http://spmjs.io.
