### PR TITLE
s/Mousetrap/mousetrap/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mousetrap",
+  "name": "mousetrap",
   "version": "1.4.6",
   "description": "Simple library for handling keyboard shortcuts",
   "main": "mousetrap.js",


### PR DESCRIPTION
I'm taking over the `mousetrap` npm package to keep it up to date.

In order for the canonical `ccampbell/mousetrap` repo to be publishable to the existing `mousetrap` npm package, the name needs to be downcased in package.json. npm has also been enforcing lowercase package names for a while now, so yeah..
