### PR TITLE
Add packaging for Meteor.js, http://meteor.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.build*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,11 +34,30 @@ module.exports = function(grunt) {
                     '!plugins/**/*.min.js'
                 ]
             }
+        },
+
+        shell: {
+            'meteor-test': {
+                command: 'meteor/runtests.sh'
+            },
+            'meteor-publish': {
+                command: 'meteor/publish.sh'
+            }
         }
+
     });
 
     grunt.loadNpmTasks('grunt-complexity');
     grunt.loadNpmTasks('grunt-mocha');
+    grunt.loadNpmTasks('grunt-shell');
+
+    // Meteor tasks
+    grunt.registerTask('meteor-test', 'shell:meteor-test');
+    grunt.registerTask('meteor-publish', 'shell:meteor-publish');
+    // Ideally we'd run tests before publishing, but the chances of tests breaking (given that
+    // Meteor is orthogonal to the library) are so small that it's not worth the maintainer's time
+    // grunt.regsterTask('meteor', ['shell:meteor-test', 'shell:meteor-publish']);
+    grunt.registerTask('meteor', 'shell:meteor-publish');
 
     grunt.registerTask('default', [
         'complexity',

--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,26 @@
+Packaging [Mousetrap](http://craig.is/killing/mice) for [Meteor.js](http://meteor.com).
+
+
+# Meteor
+
+If you're new to Meteor, here's what the excitement is all about -
+[watch the first two minutes](https://www.youtube.com/watch?v=fsi0aJ9yr2o); you'll be hooked by 1:28.
+
+That screencast is from 2012. In the meantime, Meteor has become a mature JavaScript-everywhere web
+development framework with numerous [advantages](http://www.meteorpedia.com/read/Why_Meteor) over all
+other single-page application frameworks.
+
+
+# Issues
+
+If you encounter an issue while using this package, please CC @dandv when you file it in this repo.
+
+
+# DONE
+
+* Instantiation and basic functionality test
+
+
+# TODO
+
+* Test to ensure bindings are preserved when re-rendering templates

--- a/meteor/export.js
+++ b/meteor/export.js
@@ -1,0 +1,6 @@
+// expose Mousetrap to Meteor.js
+if (typeof Package !== 'undefined') {
+  /*global Mousetrap:true*/  // Meteor.js creates a file-scope global for exporting. This comment prevents a potential JSHint warning.
+  Mousetrap = window.Mousetrap;
+  delete window.Mousetrap;
+}

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,30 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'mousetrap:mousetrap';  // https://atmospherejs.com/mousetrap/mousetrap
+var where = 'client';  // where to install: 'client', 'server', or ['client', 'server']
+
+var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));
+
+Package.describe({
+  name: packageName,
+  summary: 'Mousetrap (official): bind, trigger and handle keyboard events on keys, combinations and sequences',
+  version: packageJson.version,
+  git: 'https://github.com/ccampbell/mousetrap.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+  api.export('Mousetrap');
+  api.addFiles([
+    'mousetrap.js',
+    'meteor/export.js'
+  ], where);
+});
+
+Package.onTest(function (api) {
+  api.use(packageName, where);
+  api.use('tinytest', where);
+
+  api.addFiles('meteor/test.js', where);
+});

--- a/meteor/publish.sh
+++ b/meteor/publish.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Publish package on Meteor's Atmospherejs.com
+
+# Make sure Meteor is installed, per https://www.meteor.com/install.
+# The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+cd "$( dirname "$0" )/.."
+
+# Meteor expects package.js in the root directory of the checkout, so copy it there temporarily
+cp meteor/package.js .
+
+# publish package
+PACKAGE_NAME=$(grep -i name package.js | head -1 | cut -d "'" -f 2)
+
+echo "Publishing $PACKAGE_NAME..."
+
+# Attempt to re-publish the package - the most common operation once the initial release has
+# been made. If the package name was changed (rare), you'll have to pass the --create flag.
+meteor publish "$@"; EXIT_CODE=$?
+if (( $EXIT_CODE == 0 )); then
+  echo "Thanks for releasing a new version. You can see it at"
+  echo "https://atmospherejs.com/${PACKAGE_NAME/://}"
+else
+  echo "We got an error. Please post it at https://github.com/raix/Meteor-community-discussions/issues/14"
+fi
+
+# rm the temporary build files and package.js
+rm -rf ".build.$PACKAGE_NAME" versions.json package.js
+
+exit $EXIT_CODE

--- a/meteor/runtests.sh
+++ b/meteor/runtests.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Test Meteor package before publishing to Atmospherejs.com
+
+# Make sure Meteor is installed, per https://www.meteor.com/install.
+# The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+cd "$( dirname "$0" )/.."
+
+# run tests and delete the temporary package.js even if Ctrl+C is pressed
+int_trap() {
+  echo
+  printf "Tests interrupted. Hopefully you verified in the browser that tests pass?\n\n"
+}
+
+trap int_trap INT
+
+PACKAGE_NAME=$(grep -i name package.js | head -1 | cut -d "'" -f 2)
+
+echo "Testing $PACKAGE_NAME..."
+
+# Meteor expects package.js in the root directory of the checkout, so copy it there temporarily
+cp meteor/package.js .
+
+# provide an invalid MONGO_URL so Meteor doesn't bog us down with an empty Mongo database
+MONGO_URL=mongodb:// meteor test-packages ./
+
+# cleanup temporary build files and package.js
+rm -rf ".build.$PACKAGE_NAME" ".build.local-test:$PACKAGE_NAME" versions.json package.js

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Tinytest.addAsync('To pass this test, press "m"', function (test, done) {
+  Mousetrap.bind('m', function() {
+    test.ok({message: 'Test passed by pressing "k". Just kidding, by pressing "m".'});
+    done();
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-complexity": "~0.1.2",
-    "grunt-mocha": "~0.3.1"
+    "grunt-mocha": "~0.3.1",
+    "grunt-shell": "^1.1.1"
   }
 }


### PR DESCRIPTION
Hi Craig,

I'm a Meteor.js dev and volunteer package maintainer for [Meteor](http://meteor.com).  Mousetrap is a great keyboard handling library, and adding it to Meteor's ecosystem will expose it to many new devs (Meteor has 20k+ stars on GitHub), likely bringing in new testers and contributors. (Since it's a full-stack framework supporting Isomorphic JavaScript, [Meteor needs its own package system](https://github.com/mbostock/d3/pull/2130#issuecomment-64965661); otherwise we'd just point it to your repo.)

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click _SIGN IN_, then _Create account_). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

There's nothing else you need to do now, since I've already published the current version of the package on [Atmosphere](https://atmospherejs.com/mousetrap/mousetrap) (Meteor's package directory). When you release new versions, you can publish them with `grunt meteor` (make sure to update the `version` in `package.json`, or meteor will say `Version already exists`).

Thanks & best regards,
Dan, [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)
