### PR TITLE
Added Mousetrap.bindTo helper for event targeting

### DIFF
--- a/plugins/bind-to/README.md
+++ b/plugins/bind-to/README.md
@@ -1,0 +1,15 @@
+# Bind To
+
+This extension allows you to bind key events to specific elements using the `target` property of the event object.
+
+Usage looks like:
+
+```javascript
+Mousetrap.bindTo(element, 'mod+s', function() {
+    console.log('saved!');
+});
+```
+
+You can optionally pass in ``keypress``, ``keydown`` or ``keyup`` as a second argument.
+
+Other bind calls work the same way as they do by default.

--- a/plugins/bind-to/mousetrap-bind-to.js
+++ b/plugins/bind-to/mousetrap-bind-to.js
@@ -1,0 +1,49 @@
+Mousetrap = (function(Mousetrap) {
+
+    var self = Mousetrap;
+
+    /**
+     * @method bindTo
+     * @param {HTMLElement} element
+     * @param {String|Array} keys
+     * @param {Function} callback
+     * @param {String} action
+     * @return {void}
+     */
+    self.bindTo = function(element, keys, callback, action) {
+
+        if (!element.hasAttribute('tabindex')) {
+
+            // For elements to allow focus they require a `tabindex` attribute.
+            element.setAttribute('tabindex', 0);
+
+        }
+
+        /**
+         * @method target
+         * @param {Object} event
+         * @return {void}
+         */
+        function target(event) {
+
+            if (element === event.target || element === event.relatedTarget) {
+                callback(event);
+            }
+
+        }
+
+        if (typeof keys == 'string' || keys instanceof Array) {
+            return self.bind(keys, target, action);
+        }
+
+        for (var key in keys) {
+            if (keys.hasOwnProperty(key)) {
+                self.bind(key, keys[key], target);
+            }
+        }
+
+    };
+
+    return self;
+
+})(Mousetrap);

--- a/plugins/bind-to/mousetrap-bind-to.min.js
+++ b/plugins/bind-to/mousetrap-bind-to.min.js
@@ -1,0 +1,1 @@
+Mousetrap=function(t){var r=t;return r.bindTo=function(t,n,e,i){function a(r){(t===r.target||t===r.relatedTarget)&&e(r)}if(t.hasAttribute("tabindex")||t.setAttribute("tabindex",0),"string"==typeof n||n instanceof Array)return r.bind(n,a,i);for(var o in n)n.hasOwnProperty(o)&&r.bind(o,n[o],a)},r}(Mousetrap);


### PR DESCRIPTION
Added `Mousetrap.bindTo` helper which allows us to specify an element to listen for events on; the events then bubble to the `document` element where `Mousetrap` is ready and waiting for the event. We do a quick check on `e.target` and `e.relatedTarget` before invoking the callback.

However, although this helper works, if you specify multiple event listeners with different elements &mdash; yet using the same keys &mdash; then the callbacks are of course overwritten, which is the default behaviour of `Mousetrap` and it doesn't appear as though you're able to modify this behaviour.

Therefore I wouldn't mind some help in figuring out how to allow multiple events on the same key when you're using the event with an element context :+1: Thanks...