### PR TITLE
Allow mousetrap to bind to specific elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mousetrap is a simple library for handling keyboard shortcuts in Javascript.
 
 It is licensed under the Apache 2.0 license.
 
-It is around **1.9kb** minified and gzipped and **3.5kb** minified, has no external dependencies, and has been tested in the following browsers:
+It is around **2kb** minified and gzipped and **4.5kb** minified, has no external dependencies, and has been tested in the following browsers:
 
 - Internet Explorer 6+
 - Safari

--- a/plugins/bind-dictionary/mousetrap-bind-dictionary.js
+++ b/plugins/bind-dictionary/mousetrap-bind-dictionary.js
@@ -14,26 +14,26 @@
  *
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
-    var self = Mousetrap,
-        _oldBind = self.bind,
-        args;
+(function(Mousetrap) {
+    var _oldBind = Mousetrap.prototype.bind;
+    var args;
 
-    self.bind = function() {
+    Mousetrap.prototype.bind = function() {
+        var self = this;
         args = arguments;
 
         // normal call
         if (typeof args[0] == 'string' || args[0] instanceof Array) {
-            return _oldBind(args[0], args[1], args[2]);
+            return _oldBind.call(self, args[0], args[1], args[2]);
         }
 
         // object passed in
         for (var key in args[0]) {
             if (args[0].hasOwnProperty(key)) {
-                _oldBind(key, args[0][key], args[1]);
+                _oldBind.call(self, key, args[0][key], args[1]);
             }
         }
     };
 
-    return self;
+    Mousetrap.init();
 }) (Mousetrap);

--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -7,20 +7,27 @@
  * Mousetrap.bindGlobal('ctrl+s', _saveChanges);
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
-    var _globalCallbacks = {},
-        _originalStopCallback = Mousetrap.stopCallback;
+(function(Mousetrap) {
+    var _globalCallbacks = {};
+    var _originalStopCallback = Mousetrap.prototype.stopCallback;
 
-    Mousetrap.stopCallback = function(e, element, combo, sequence) {
+    Mousetrap.prototype.stopCallback = function(e, element, combo, sequence) {
+        var self = this;
+
+        if (self.paused) {
+            return true;
+        }
+
         if (_globalCallbacks[combo] || _globalCallbacks[sequence]) {
             return false;
         }
 
-        return _originalStopCallback(e, element, combo);
+        return _originalStopCallback.call(self, e, element, combo);
     };
 
-    Mousetrap.bindGlobal = function(keys, callback, action) {
-        Mousetrap.bind(keys, callback, action);
+    Mousetrap.prototype.bindGlobal = function(keys, callback, action) {
+        var self = this;
+        self.bind(keys, callback, action);
 
         if (keys instanceof Array) {
             for (var i = 0; i < keys.length; i++) {
@@ -32,5 +39,5 @@ Mousetrap = (function(Mousetrap) {
         _globalCallbacks[keys] = true;
     };
 
-    return Mousetrap;
+    Mousetrap.init();
 }) (Mousetrap);

--- a/plugins/pause/mousetrap-pause.js
+++ b/plugins/pause/mousetrap-pause.js
@@ -4,26 +4,28 @@
  * without having to reset Mousetrap and rebind everything
  */
 /* global Mousetrap:true */
-Mousetrap = (function(Mousetrap) {
-    var self = Mousetrap,
-        _originalStopCallback = self.stopCallback,
-        enabled = true;
+(function(Mousetrap) {
+    var _originalStopCallback = Mousetrap.prototype.stopCallback;
 
-    self.stopCallback = function(e, element, combo) {
-        if (!enabled) {
+    Mousetrap.prototype.stopCallback = function(e, element, combo) {
+        var self = this;
+
+        if (self.paused) {
             return true;
         }
 
-        return _originalStopCallback(e, element, combo);
+        return _originalStopCallback.call(self, e, element, combo);
     };
 
-    self.pause = function() {
-        enabled = false;
+    Mousetrap.prototype.pause = function() {
+        var self = this;
+        self.paused = true;
     };
 
-    self.unpause = function() {
-        enabled = true;
+    Mousetrap.prototype.unpause = function() {
+        var self = this;
+        self.paused = false;
     };
 
-    return self;
+    Mousetrap.init();
 }) (Mousetrap);

--- a/plugins/record/mousetrap-record.js
+++ b/plugins/record/mousetrap-record.js
@@ -46,7 +46,7 @@
          *
          * @type {Function}
          */
-        _origHandleKey = Mousetrap.handleKey;
+        _origHandleKey = Mousetrap.prototype.handleKey;
 
     /**
      * handles a character key event
@@ -57,6 +57,13 @@
      * @returns void
      */
     function _handleKey(character, modifiers, e) {
+        var self = this;
+
+        if (!self.recording) {
+            _origHandleKey.apply(self, arguments);
+            return;
+        }
+
         // remember this character if we're currently recording a sequence
         if (e.type == 'keydown') {
             if (character.length === 1 && _recordedCharacterKey) {
@@ -157,8 +164,6 @@
         _recordedSequence = [];
         _recordedSequenceCallback = null;
         _currentRecordedKeys = [];
-
-        Mousetrap.handleKey = _origHandleKey;
     }
 
     /**
@@ -181,9 +186,20 @@
      * @param {Function} callback
      * @returns void
      */
-    Mousetrap.record = function(callback) {
-        Mousetrap.handleKey = _handleKey;
-        _recordedSequenceCallback = callback;
+    Mousetrap.prototype.record = function(callback) {
+        var self = this;
+        self.recording = true;
+        _recordedSequenceCallback = function() {
+            self.recording = false;
+            callback.apply(self, arguments);
+        };
     };
+
+    Mousetrap.prototype.handleKey = function() {
+        var self = this;
+        _handleKey.apply(self, arguments);
+    };
+
+    Mousetrap.init();
 
 })(Mousetrap);

--- a/tests/mousetrap.html
+++ b/tests/mousetrap.html
@@ -5,6 +5,11 @@
     <link rel="stylesheet" href="libs/mocha-1.9.0.css" />
 </head>
 <body>
+    <!-- used to test targeted keyboard shortcuts w/ Mousetrap.wrap -->
+    <form style="display: none;">
+        <textarea></textarea>
+    </form>
+
     <div id="mocha"></div>
     <script src="../mousetrap.js"></script>
     <script src="libs/key-event.js"></script>

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -617,3 +617,42 @@ describe('Mousetrap.unbind', function() {
         expect(spy.callCount).to.equal(3, 'callback should not fire after unbind');
     });
 });
+
+describe('wrapping a specific element', function() {
+    var form = document.querySelector('form');
+    var textarea = form.querySelector('textarea');
+
+    it('z key fires when pressing z in the target element', function() {
+        var spy = sinon.spy();
+
+        Mousetrap(form).bind('z', spy);
+
+        KeyEvent.simulate('Z'.charCodeAt(0), 90, [], form);
+
+        expect(spy.callCount).to.equal(1, 'callback should fire once');
+        expect(spy.args[0][0]).to.be.an.instanceOf(Event, 'first argument should be Event');
+        expect(spy.args[0][1]).to.equal('z', 'second argument should be key combo');
+    });
+
+    it('z key fires when pressing z in a child of the target element', function() {
+        var spy = sinon.spy();
+
+        Mousetrap(form).bind('z', spy);
+
+        KeyEvent.simulate('Z'.charCodeAt(0), 90, [], textarea);
+
+        expect(spy.callCount).to.equal(1, 'callback should fire once');
+        expect(spy.args[0][0]).to.be.an.instanceOf(Event, 'first argument should be Event');
+        expect(spy.args[0][1]).to.equal('z', 'second argument should be key combo');
+    });
+
+    it('z key does not fire when pressing z outside the target element', function() {
+        var spy = sinon.spy();
+
+        Mousetrap(textarea).bind('z', spy);
+
+        KeyEvent.simulate('Z'.charCodeAt(0), 90);
+
+        expect(spy.callCount).to.equal(0, 'callback should not have fired');
+    });
+});

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -655,4 +655,17 @@ describe('wrapping a specific element', function() {
 
         expect(spy.callCount).to.equal(0, 'callback should not have fired');
     });
+
+    it('should work when constructing a new mousetrap object', function() {
+        var spy = sinon.spy();
+
+        var mousetrap = new Mousetrap(form);
+        mousetrap.bind('a', spy);
+
+        KeyEvent.simulate('a'.charCodeAt(0), 65, [], textarea);
+
+        expect(spy.callCount).to.equal(1, 'callback should fire once');
+        expect(spy.args[0][0]).to.be.an.instanceOf(Event, 'first argument should be Event');
+        expect(spy.args[0][1]).to.equal('a', 'second argument should be key combo');
+    });
 });


### PR DESCRIPTION
Making a pull request for myself before I push this out so I can look it over.

This allows you to use Mousetrap like this:

```javascript

// works like normal
Mousetrap.bind('a', function(e, keys) { console.log(keys); });

// wrap a specific element
var textArea = document.querySelector('textarea');
Mousetrap(textArea).bind('ctrl+s', _handleSave);

// wrap a form containing elements
var form = document.querySelector('form');
Mousetrap(form).bind('ctrl+s', _handleSave);

// create a new Mousetrap instance
var mousetrap = new Mousetrap(someElement);
mousetrap.bind(key1, callback1);
mousetrap.bind(key2, callback2);
```