### PR TITLE
Don't fire events if you're inside a textfield/input in a shadow DOM

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -598,7 +598,7 @@
         function _fireCallback(callback, e, combo, sequence) {
 
             // if this event should not happen stop here
-            var element = typeof e.path == 'object' && e.path.constructor == Array ? e.path[0]  : e.target || e.srcElement;
+            var element = typeof e.path === 'object' && e.path.constructor === Array ? e.path[0]  : e.target || e.srcElement;
             if (self.stopCallback(e, element, combo, sequence)) {
                 return;
             }

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -410,7 +410,7 @@
     }
 
     function _belongsTo(element, ancestor) {
-        if (element === document) {
+        if (element === document || element === null) {
             return false;
         }
 
@@ -598,7 +598,8 @@
         function _fireCallback(callback, e, combo, sequence) {
 
             // if this event should not happen stop here
-            if (self.stopCallback(e, e.target || e.srcElement, combo, sequence)) {
+            var element = typeof e.path == 'object' && e.path.constructor == Array ? e.path[0]  : e.target || e.srcElement;
+            if (self.stopCallback(e, element, combo, sequence)) {
                 return;
             }
 

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -70,6 +70,16 @@ describe('Mousetrap.bind', function() {
             }
         });
 
+        it('z key does not fire when inside an input element', function() {
+            var textarea = document.querySelector('textarea');
+            var spy = sinon.spy();
+
+            Mousetrap.bind('z', spy);
+            KeyEvent.simulate('Z'.charCodeAt(0), 90, [], textarea);
+
+            expect(spy.callCount).to.equal(0, 'callback should not have fired');
+        });
+
         it('keyup events should fire', function() {
             var spy = sinon.spy();
 

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -80,6 +80,25 @@ describe('Mousetrap.bind', function() {
             expect(spy.callCount).to.equal(0, 'callback should not have fired');
         });
 
+        it('z key does not fire when inside an input element in a shadow dom', function() {
+            var shadow = document.createElement('div');
+            shadow.style.display = 'none';
+            shadow.createShadowRoot();
+            document.body.appendChild(shadow);
+
+            var input = document.createElement('input');
+            shadow.shadowRoot.appendChild(input);
+
+            var spy = sinon.spy();
+
+            Mousetrap.bind('z', spy);
+            KeyEvent.simulate('Z'.charCodeAt(0), 90, [], input);
+
+            document.body.removeChild(shadow);
+
+            expect(spy.callCount).to.equal(0, 'callback should not have fired');
+        });
+
         it('keyup events should fire', function() {
             var spy = sinon.spy();
 


### PR DESCRIPTION
Events occuring in a shadow DOM are [retargeted](http://www.w3.org/TR/shadow-dom/#event-retargeting) to look like they come from the host element. Use `event.path` rather than `event.target` to get the actual element in which the event occured.

This pull request fixes #245.
