### PR TITLE
Changing to work correctly with numpad 0.

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -200,11 +200,11 @@
         }
 
         // for non keypress events the special maps are needed
-        if (_MAP[e.which]) {
+        if (_MAP[e.which] !== undefined) {
             return _MAP[e.which];
         }
 
-        if (_KEYCODE_MAP[e.which]) {
+        if (_KEYCODE_MAP[e.which] !== undefined) {
             return _KEYCODE_MAP[e.which];
         }
 
@@ -713,7 +713,7 @@
             var character = _characterFromEvent(e);
 
             // no character found then stop
-            if (!character) {
+            if (character === undefined) {
                 return;
             }
 


### PR DESCRIPTION
Numpad 0 returns keycode 96, wich is mapped `_MAP` variable. 
Since 0 is false, it does not recognize correctly. For example, pressing ctrl + numpad 0 will recognize ctrl+`