### PR TITLE
Avoid using instanceof; fixes #105

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -896,7 +896,7 @@
      */
     Mousetrap.prototype.bind = function(keys, callback, action) {
         var self = this;
-        keys = keys instanceof Array ? keys : [keys];
+        keys = Mousetrap._isArray(keys) ? keys : [keys];
         self._bindMultiple.call(self, keys, callback, action);
         return self;
     };
@@ -981,6 +981,16 @@
     Mousetrap.prototype.handleKey = function() {
         var self = this;
         return self._handleKey.apply(self, arguments);
+    };
+
+    /**
+     * checks if the value is an array
+     *
+     * @param {*} value
+     * @returns {boolean}
+     */
+    Mousetrap._isArray = function(value) {
+        return Object.prototype.toString.call(value) == '[object Array]';
     };
 
     /**

--- a/plugins/bind-dictionary/mousetrap-bind-dictionary.js
+++ b/plugins/bind-dictionary/mousetrap-bind-dictionary.js
@@ -23,7 +23,7 @@
         args = arguments;
 
         // normal call
-        if (typeof args[0] == 'string' || args[0] instanceof Array) {
+        if (typeof args[0] == 'string' || Mousetrap._isArray(args[0])) {
             return _oldBind.call(self, args[0], args[1], args[2]);
         }
 

--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -29,7 +29,7 @@
         var self = this;
         self.bind(keys, callback, action);
 
-        if (keys instanceof Array) {
+        if (Mousetrap._isArray(keys)) {
             for (var i = 0; i < keys.length; i++) {
                 _globalCallbacks[keys[i]] = true;
             }


### PR DESCRIPTION
I've just run into the same issue as @July-G. `instanceof` doesn't work when you use an array from a different js context.

The correct way to check for an array is using either `Array.isArray()`, or `Object#toString()`, if support for older browsers is needed.

I added the function to `Mousetrap` object, so that it can be used by plugins as well.
