### PR TITLE
Allow pausing and unpausing of specific combos

### DIFF
--- a/plugins/pause/mousetrap-pause.js
+++ b/plugins/pause/mousetrap-pause.js
@@ -10,7 +10,15 @@
     Mousetrap.prototype.stopCallback = function(e, element, combo) {
         var self = this;
 
+        if (self.isUnpausedCombo(combo)) {
+            return _originalStopCallback.call(self, e, element, combo);
+        }
+
         if (self.paused) {
+            return true;
+        }
+
+        if (self.isPausedCombo(combo)) {
             return true;
         }
 
@@ -25,6 +33,48 @@
     Mousetrap.prototype.unpause = function() {
         var self = this;
         self.paused = false;
+    };
+
+    Mousetrap.prototype.isUnpausedCombo = function(combo) {
+        return (self.unpausedCombos && -1 < self.unpausedCombos.indexOf(combo));
+    };
+
+    Mousetrap.prototype.isPausedCombo = function(combo) {
+        return (self.pausedCombos && -1 < self.pausedCombos.indexOf(combo));
+    };
+
+    Mousetrap.prototype.pauseCombo = function(combo) {
+        var self = this;
+        if (self.paused) {
+            if (self.isUnpausedCombo(combo)) {
+                var index = self.unpausedCombos.indexOf(combo);
+                if (-1 < index) {
+                    self.unpausedCombos.splice(index, 1);
+                }
+            }
+        } else {
+            if (!self.pausedCombos) {
+                self.pausedCombos = [];
+            }
+            self.pausedCombos.push(combo);
+        }
+    };
+
+    Mousetrap.prototype.unpauseCombo = function(combo) {
+        var self = this;
+        if (self.paused) {
+            if (!self.unpausedCombos) {
+                self.unpausedCombos = [];
+            }
+            self.unpausedCombos.push(combo);
+        } else {
+            if (self.isPausedCombo(combo)) {
+                var index = self.pausedCombos.indexOf(combo);
+                if (-1 < index) {
+                    self.pausedCombos.splice(index, 1);
+                }
+            }
+        }
     };
 
     Mousetrap.init();


### PR DESCRIPTION
With this patch, you may pause specific combos, only.

Otherwise you may allow specific combos even if globally paused.