### PR TITLE
Enhancements in record plugin

### DIFF
--- a/plugins/record/README.md
+++ b/plugins/record/README.md
@@ -4,6 +4,7 @@ This extension lets you use Mousetrap to record keyboard sequences and play them
 
 ```html
 <button onclick="recordSequence()">Record</button>
+<button onclick="stopRecord()">Stop</button>
 
 <script>
     function recordSequence() {
@@ -11,6 +12,9 @@ This extension lets you use Mousetrap to record keyboard sequences and play them
             // sequence is an array like ['ctrl+k', 'c']
             alert('You pressed: ' + sequence.join(' '));
         });
+    }
+    function stopRecord() {
+        Mousetrap.stopRecord();
     }
 </script>
 ```


### PR DESCRIPTION
Here is the list of enhancements:

- Added `stopRecord` function
- Added option to disable sequence recording and to avoid the `setTimeout` (option is called `recordSequence` and is `true` by default, which is the original behavior)
- Call `e.preventDefault()` in `_handleKey` to allow capturing browser shortcuts (`mod+s` for example)
- Allow to call back the `record` function in the callback, sounds more like a bug fix ;)