### PR TITLE
Fix issue with key events not firing in IE10

### DIFF
--- a/tests/libs/key-event.js
+++ b/tests/libs/key-event.js
@@ -18,7 +18,14 @@
     };
 
     KeyEvent.prototype.toNative = function() {
-        var event = document.createEventObject ? document.createEventObject() : document.createEvent('Events');
+        var event;
+
+        // Events created with createEventObject() in IE 10 don't work with setting properties like `which`, etc.
+        if (/*@cc_on!@*/false && document.documentMode === 10) {
+            event = document.createEvent('HTMLEvents');
+        } else {
+            event = document.createEventObject ? document.createEventObject() : document.createEvent('Events');
+        }
 
         if (event.initEvent) {
             event.initEvent(this.type, true, true);


### PR DESCRIPTION
Fixes #279. The events created appear to be read only, so setting properties like `which` and `keyCode`, etc. didn't have any effect on the events that were dispatched. 
