### PR TITLE
Ability to have custom key mappings

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -984,6 +984,19 @@
     };
 
     /**
+     * allow custom key mappings
+     */
+    Mousetrap.extendMap = function(object) {
+      var key;
+      for (key in object) {
+          if (object.hasOwnProperty(key)) {
+              _MAP[key] = object[key];
+          }
+      }
+      _REVERSE_MAP = null;
+    }
+
+    /**
      * Init the global mousetrap functions
      *
      * This method is needed to allow the global mousetrap functions to work

--- a/tests/test.mousetrap.js
+++ b/tests/test.mousetrap.js
@@ -682,3 +682,16 @@ describe('wrapping a specific element', function() {
         expect(spy.args[0][1]).to.equal('a', 'second argument should be key combo');
     });
 });
+
+describe('Mouestra.extendMap', function() {
+  it('should properly recognize non-default mapping', function() {
+    var spy = sinon.spy();
+    Mousetrap.extendMap({
+      144: 'num',
+    });
+    Mousetrap.bind('num', spy);
+    KeyEvent.simulate(144, 144);
+    expect(spy.callCount).to.equal(1, 'callback should fire for num');
+    spy.reset();
+  });
+});


### PR DESCRIPTION
A re-implementation of PR #50 with tests included, a slight difference, `extend` is now `extendMap`

```
Mousetrap.extendMap({
  173: 'mute',
  174: 'volumedown',
  175: 'volumeup',
  176: 'nexttrack',
  177: 'previoustrack',
  178: 'stop',
  179: 'playpause'
});
```