### PR TITLE
Added Mousetrap.unbindGlobal base on Mousetrap.unbind.

### DIFF
--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -38,6 +38,20 @@
 
         _globalCallbacks[keys] = true;
     };
+	
+	Mousetrap.prototype.unbindGlobal = function(keys, action) {
+		var self = this;
+		self.unbind(keys, action);
+
+		if (keys instanceof Array) {
+			for (var i = 0; i < keys.length; i++) {
+				_globalCallbacks[keys[i]] = false;
+			}
+			return;
+		}
+
+		_globalCallbacks[keys] = false;
+	};
 
     Mousetrap.init();
 }) (Mousetrap);


### PR DESCRIPTION
Hi,

After viewing issue #306 I was thinking of contributing to the plugin because I need an unbindGlobal method.
I didn't modified the min.js version beacause I didn't found how to regenerate it.

I hope it helps.