### PR TITLE
Add npm instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ It has support for ``keypress``, ``keydown``, and ``keyup`` events on specific k
     ```html
     <script src="/path/to/mousetrap.min.js"></script>
     ```
+    
+    or install `mousetrap` from `npm` and require it
+    
+    ```js
+    var Mousetrap = require('mousetrap');
+    ```
 
 2.  Add some keyboard events to listen for
 


### PR DESCRIPTION
When looking for libraries, I'm pleased to know right off the bat if it's published on NPM (which typically indicates it's got modular design in mind).
