### PR TITLE
don't block modifier key combos such as ctrl+k in inputs

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -970,8 +970,13 @@
      * @param {Element} element
      * @return {boolean}
      */
-    Mousetrap.prototype.stopCallback = function(e, element) {
+    Mousetrap.prototype.stopCallback = function(e, element, combo) {
         var self = this;
+        
+        // don't block modifier key combos such as ctrl+k
+        if (combo.indexOf('mod') !== -1 || combo.indexOf('alt') !== -1) {
+            return false;
+        }
 
         // if the element has the class "mousetrap" then no need to stop
         if ((' ' + element.className + ' ').indexOf(' mousetrap ') > -1) {


### PR DESCRIPTION
I recently found that blocking "regular combos" such as ctrl+k or alt+w in input elements confuse users badly.

Since those combos don't hurt in input fields, the default should let them through.