### PR TITLE
Add firefox keycodes for '=' and '-'.

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -72,9 +72,11 @@
     var _KEYCODE_MAP = {
         106: '*',
         107: '+',
+        61: '=', // FF keyCode for '=' (same as on keypress)
         109: '-',
         110: '.',
         111 : '/',
+        173: '-', // FF keyCode for '-'
         186: ';',
         187: '=',
         188: ',',


### PR DESCRIPTION
This should resolve issues referenced in pull request #215 (https://github.com/ccampbell/mousetrap/pull/215).
The above pull request can't be merged as of now. This will be useful to resolve bugs downstream.