### PR TITLE
Make global-bind plugin safe in node envs

### DIFF
--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -8,6 +8,9 @@
  */
 /* global Mousetrap:true */
 (function(Mousetrap) {
+    if (! Mousetrap) {
+        return;
+    }
     var _globalCallbacks = {};
     var _originalStopCallback = Mousetrap.prototype.stopCallback;
 


### PR DESCRIPTION
When mousetrap loads in a non-dom environment, it bails early and doesn't set the Mousetrap global. Make the global-bind plugin detect that Mousetrap didn't initialize and bail itself.