### PR TITLE
support Opera Mini on any iphone

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -132,7 +132,7 @@
         'return': 'enter',
         'escape': 'esc',
         'plus': '+',
-        'mod': /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? 'meta' : 'ctrl'
+        'mod': /Mac|iPod|iPhone|iPad|Pike/.test(navigator.platform) ? 'meta' : 'ctrl'
     };
 
     /**


### PR DESCRIPTION
thx! i like this repo.

there a [list](https://stackoverflow.com/a/19883965) about all the result of `navigator.platform`.

maybe we lost something about opera mini:

- Pike v7.6 release 92: Opera Mini 5 on any iPhone (2009)
- Pike v7.8 release 517: Opera Mini 7 on any iPhone (2012)