### PR TITLE
Make global-bind plugin safe in node envs, part 2

### DIFF
--- a/plugins/global-bind/mousetrap-global-bind.js
+++ b/plugins/global-bind/mousetrap-global-bind.js
@@ -43,4 +43,4 @@
     };
 
     Mousetrap.init();
-}) (Mousetrap);
+}) (typeof Mousetrap !== "undefined" ? Mousetrap : undefined);


### PR DESCRIPTION
Follow on from #465, which missed the ReferenceError from trying to use the Mousetrap global at the end of the file.