### PR TITLE
Proper variable declaration

### DIFF
--- a/plugins/record/mousetrap-record.js
+++ b/plugins/record/mousetrap-record.js
@@ -58,6 +58,7 @@
      */
     function _handleKey(character, modifiers, e) {
         var self = this;
+        var i;
 
         if (!self.recording) {
             _origHandleKey.apply(self, arguments);


### PR DESCRIPTION
Variable "i" from for-cycle was undeclared, so when the code was run in strict mode, it failed.

(As I am doing the change via GitHub online editor, I am not attaching minified plugin version.)