### PR TITLE
dx(types): Add types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Mousetrap
 [![CDNJS](https://img.shields.io/cdnjs/v/mousetrap.svg)](https://cdnjs.com/libraries/mousetrap)
 
+This is the Codesphere fork of Mousetrap. Mousetrap is no longer actively, the last commit was in January of 2020.
+Since we want some minimal changes in the library we decided to fork it into our org.
+
 Mousetrap is a simple library for handling keyboard shortcuts in Javascript.
 
 It is licensed under the Apache 2.0 license.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+declare namespace Mousetrap {
+	interface ExtendedKeyboardEvent extends KeyboardEvent {
+		returnValue: boolean; // IE returnValue
+	}
+
+	interface MousetrapStatic {
+		(el?: Element): MousetrapInstance;
+		new (el?: Element, useCapture?: boolean): MousetrapInstance;
+		addKeycodes(keycodes: { [key: number]: string }): void;
+		stopCallback: (
+			e: ExtendedKeyboardEvent,
+			element: Element,
+			combo: string,
+		) => boolean;
+		bind(
+			keys: string | string[],
+			// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+			callback: (e: ExtendedKeyboardEvent, combo: string) => boolean | void,
+			action?: string,
+		): MousetrapInstance;
+		unbind(keys: string | string[], action?: string): MousetrapInstance;
+		trigger(keys: string, action?: string): MousetrapInstance;
+		reset(): MousetrapInstance;
+	}
+
+	interface MousetrapInstance {
+		stopCallback: (
+			e: ExtendedKeyboardEvent,
+			element: Element,
+			combo: string,
+		) => boolean;
+		bind(
+			keys: string | string[],
+			callback: (e: ExtendedKeyboardEvent, combo: string) => void,
+			action?: string,
+		): this;
+		unbind(keys: string | string[], action?: string): this;
+		trigger(keys: string, action?: string): this;
+		handleKey(
+			character: string,
+			modifiers: string[],
+			e: ExtendedKeyboardEvent,
+		): void;
+		reset(): this;
+	}
+}
+
+declare const Mousetrap: Mousetrap.MousetrapStatic;
+
+export = Mousetrap;
+
+export as namespace Mousetrap;

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -173,9 +173,9 @@
      * @param {Function} callback
      * @returns void
      */
-    function _addEvent(object, type, callback) {
+    function _addEvent(object, type, callback, useCapture) {
         if (object.addEventListener) {
-            object.addEventListener(type, callback, false);
+            object.addEventListener(type, callback, useCapture);
             return;
         }
 
@@ -432,10 +432,11 @@
         return _belongsTo(element.parentNode, ancestor);
     }
 
-    function Mousetrap(targetElement) {
+    function Mousetrap(targetElement, useCapture) {
         var self = this;
 
         targetElement = targetElement || document;
+        useCapture = !!useCapture;
 
         if (!(self instanceof Mousetrap)) {
             return new Mousetrap(targetElement);
@@ -886,9 +887,9 @@
         };
 
         // start!
-        _addEvent(targetElement, 'keypress', _handleKeyEvent);
-        _addEvent(targetElement, 'keydown', _handleKeyEvent);
-        _addEvent(targetElement, 'keyup', _handleKeyEvent);
+        _addEvent(targetElement, 'keypress', _handleKeyEvent, useCapture);
+        _addEvent(targetElement, 'keydown', _handleKeyEvent, useCapture);
+        _addEvent(targetElement, 'keyup', _handleKeyEvent, useCapture);
     }
 
     /**


### PR DESCRIPTION
The types are originally from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mousetrap and have been modified to allow for the second param for `useCapture` that was merged in the PR before.
